### PR TITLE
[ID-92]Webtools images fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Webtools images fixes [#92](https://github.com/rokwire/gateway-building-block/issues/92)
 
 [2.8.0] - 2024-05-05
 ### Changed

--- a/driven/image/adapter.go
+++ b/driven/image/adapter.go
@@ -87,7 +87,7 @@ func (im Adapter) downloadWebtoolImages(item model.WebToolsEvent) (*model.ImageD
 	// Check if the response status code is OK
 	if response.StatusCode != http.StatusOK {
 		im.logger.Infof("response code %d for %s", response.StatusCode, item.EventID)
-		return nil, fmt.Errorf("non-OK response status: %d", response.StatusCode)
+		return nil, nil //do not return error when cannot get/find an image
 	}
 
 	// Decode the image


### PR DESCRIPTION
## Description
1. It seems you call the Webtools image API two times. It should work with only one call.
2. When you download an image you store it on the file system. Please try without saving it but directly work with the bytes in the memory.

**Resolves #92 
# Review Time Estimate
- [ ] Immediately
- [ ] Within a week
- [X] When possible

## Type of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
- [x] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.