### PR TITLE
107 bug laundry appliance status is reported incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unpublished] - 2024-08-26
+### Changed
+- Based on data coming back from LaundryView, uiuc laundry adapter now reutrns unknown as a status when the machine is offline and the out for service flag is 0. [#107]https://github.com/rokwire/gateway-building-block/issues/107
+
 ## [2.10.3] - 2024-06-28
 ### Changed
 - Added markers and highlites parameters to floor plans endpoint to allow client to set default state. [#103](https://github.com/rokwire/gateway-building-block/issues/103)

--- a/core/model/uiuc/laundryview.go
+++ b/core/model/uiuc/laundryview.go
@@ -93,7 +93,7 @@ func NewLaundryRoom(id int, name string, status string, location *model.LaundryD
 }
 
 // NewAppliance returns an app formatted appliance ojbect from campus data
-func NewAppliance(id string, appliancetype string, cycletime int, status string, timeremaining string, label string) *model.Appliance {
+func NewAppliance(id string, appliancetype string, cycletime int, status string, timeremaining string, label string, outofserviceflag string) *model.Appliance {
 
 	var finalStatus string
 	switch status {
@@ -101,11 +101,17 @@ func NewAppliance(id string, appliancetype string, cycletime int, status string,
 		finalStatus = "available"
 	case "In Use":
 		finalStatus = "in_use"
+	case "Offline":
+		if outofserviceflag == "1" {
+			finalStatus = "out_of_service"
+		} else {
+			finalStatus = "unknown"
+		}
 	default:
-		finalStatus = "out_of_service"
+		finalStatus = "unknown"
 	}
 
-	if finalStatus == "available" || finalStatus == "out_of_service" {
+	if finalStatus == "available" || finalStatus == "out_of_service" || finalStatus == "unknown" {
 		appl := model.Appliance{ID: id, ApplianceType: appliancetype, AverageCycleTime: cycletime, Status: finalStatus, Label: label}
 		return &appl
 	}

--- a/driven/uiucadapters/laundryadapter.go
+++ b/driven/uiucadapters/laundryadapter.go
@@ -111,7 +111,7 @@ func (lv *CSCLaundryView) GetLaundryRoom(roomid string, conf *model.EnvConfigDat
 
 		for i, appl := range lr.Appliances {
 			avgCycle, _ := strconv.Atoi(appl.AvgCycleTime)
-			rd.Appliances[i] = uiuc.NewAppliance(appl.ApplianceKey, appl.ApplianceType, avgCycle, appl.Status, appl.TimeRemaining, appl.Label)
+			rd.Appliances[i] = uiuc.NewAppliance(appl.ApplianceKey, appl.ApplianceType, avgCycle, appl.Status, appl.TimeRemaining, appl.Label, appl.OutOfService)
 		}
 
 		if len(lv.laundryAssets) > 0 {


### PR DESCRIPTION
## Description
Changes the status of appliances returned to the app based on extra data coming from the laundryview adapter(UIUClaundryadapter).  If the status of the appliance is given as OffLine, the building block will also look at the out_of_service flag as well. when it is 1, out_of_service will be the status sent back to the app for the appliance. When it is 0, unknown will be the status returned.

**Resolves #107  **

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Immediately
- [ ] Within a week
- [ x] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [ ] I have updated the [CHANGELOG](../CHANGELOG.md).
- [ ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)