### PR TITLE
117 feature add section identifier to course information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UnReleased] - 2025-01-15
 ### fixed
 - When the campus API fails to return a floor plan, the building block now returns an empty floor plan object instead of a 500 status
+### added
+- Add section number to course data for MyCourses
 
 ## [2.11.1] - 2024-11-04
 ### Changed

--- a/core/model/courses.go
+++ b/core/model/courses.go
@@ -54,6 +54,7 @@ type CourseSection struct {
 	EndTime               string   `json:"endtime" bson:"endtime"`
 	Location              Building `json:"building" bson:"building"`
 	CourseReferenceNumber string   `json:"courseReferenceNumber" bson:"courseReferenceNumber"`
+	SectionNumber         string   `json:"course_section" bson:"course_section"`
 }
 
 // Course represents the full elements of a course

--- a/core/model/uiuc/courses.go
+++ b/core/model/uiuc/courses.go
@@ -148,14 +148,15 @@ func NewCourse(cr CourseRegistration, courseSectionSessionIndex int) *model.Cour
 	ret.InstructionMethod = cr.CourseSection.CourseSectionSession[courseSectionSessionIndex].ValidCourseScheduleType.Code
 	crn := cr.CourseSection.CourseReferenceNumber
 	css := cr.CourseSection.CourseSectionSession[courseSectionSessionIndex]
-	newCS := NewCourseSection(css, crn)
+	sn := cr.CourseSection.SectionNumber
+	newCS := NewCourseSection(css, crn, sn)
 	ret.Section = *newCS
 
 	return &ret
 }
 
 // NewCourseSection maps the coursesectionsession data from campus to the coursesection data sent back to the app
-func NewCourseSection(cs CourseSectionSession, crn string) *model.CourseSection {
+func NewCourseSection(cs CourseSectionSession, crn string, sn string) *model.CourseSection {
 	ret := model.CourseSection{}
 	ret.BuildingName = cs.ValidBuilding.Description
 	ret.Room = cs.Room
@@ -164,6 +165,7 @@ func NewCourseSection(cs CourseSectionSession, crn string) *model.CourseSection 
 	ret.StartTime = cs.StartTime
 	ret.EndTime = cs.EndTime
 	ret.InstructionType = cs.ValidCourseScheduleType.Code
+	ret.SectionNumber = sn
 
 	//we only want the primary instructor
 	if len(cs.CourseSectionInstructor) == 0 {


### PR DESCRIPTION
## Description
Merge changes that add the section number to the course data students see in the app.
Adds the section_number property to the json object returned by the building block to the app.

**Resolves #117 **

[

- [ x] Immediately
- [ ] Within a week
- [ ] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [ ] I have updated the [CHANGELOG](../CHANGELOG.md).
- [ ] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)