### PR TITLE
[ID-155]One webtools event id published to multiple calendars creates duplicate events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+-  One Webtools event id published to multiple calendars creates duplicate events [#155](https://github.com/rokwire/gateway-building-block/issues/155)
 
 ## [2.17.3] - 2025-07-23
 ### Changed 


### PR DESCRIPTION
## Description
A Webtools event has a unique id but can be shared across multiple Webtools calendars.

Can we prevent a Webtools event from displaying more than once in the Illinois app based on the unique Webtools event id?

Here is an example: the event "Break Program Series: Field Trip to Lake of the Woods (Mahomet, IL) RSVP REQUIRED" on August 6 displays three times in the app.

The event has one event id 33522293 but it is being pulled into the app from multiple Webtools calendars:
https://calendars.illinois.edu/detail/863?eventId=33522293
https://calendars.illinois.edu/detail/8017?eventId=33522293
https://calendars.illinois.edu/detail/852?eventId=33518713



**Resolves #155 

## Review Time Estimate
- [ ] Immediately
- [ ] Within a week
- [x] When possible

## Type of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
- [x] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.